### PR TITLE
Moved unordered list in tag_index.html outside template for-loops

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -25,17 +25,17 @@
 			<a id="{{level.tag}}"></a>
 			<h2 class="post-list-head jetsHide">{{level.title}}</h2>
 			{% assign post_list = site.tags.[{{level.tag}}] | sort: 'title' %}
-			{% for post in post_list %}
-			{% for tag in post.tags %}
-			{% if tag == page.tag %}
 			<ul class="post-list jetsContent">
+				{% for post in post_list %}
+				{% for tag in post.tags %}
+				{% if tag == page.tag %}
 				<li data-tags="{{ post.tags | join: ',' }}" data-sources="{{ post.sources | join: ',' }}">
 					<a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
 				</li>
+				{% endif %}
+				{% endfor %}
+				{% endfor %}
 			</ul>
-			{% endif %}
-			{% endfor %}
-			{% endfor %}
 			<a class="post-meta jetsHide" href="#top">Back to top &#8593;</a>
 			{% endfor %}
 		</div>


### PR DESCRIPTION
This unordered list tag was in the wrong spot. It was causing every class page (/grimoire/tags/bard.html, and the others) to add a margin below every spell name, because every spell name had its own unordered list. Check the difference between the index.html page and one of the class pages if you don't believe me - the space between spell names is much wider on the class pages.