### PR TITLE
Add SRD page number to Antipathy/Sympathy.

### DIFF
--- a/_posts/2015-01-09-antipathy-sympathy.markdown
+++ b/_posts/2015-01-09-antipathy-sympathy.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Antipathy/Sympathy"
 date:   2015-01-09
-sources: [PHB.214, SRD]
+sources: [PHB.214, SRD.117]
 tags:   [druid, wizard, level8, enchantment]
 ---
 


### PR DESCRIPTION
We can see based off of the SRD: https://media.wizards.com/2016/downloads/SRD-OGL_V1.1.pdf

That it is on page 117.

I made a change on the web UI, let me know if I need to run a build step or something else.